### PR TITLE
fix: other fixes to work with zig 0.8.0

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: master
+          version: 0.8.0
       - run: sudo apt-get update
       - run: sudo apt-get install libglfw3 libglfw3-dev libsystemd-dev libudev-dev libinput-dev libdrm-dev libxkbcommon-dev
       - run: zig build
@@ -20,5 +20,5 @@ jobs:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: master
+          version: 0.8.0
       - run: zig fmt --check src/*.zig

--- a/src/backend/drm/systemd.zig
+++ b/src/backend/drm/systemd.zig
@@ -54,7 +54,7 @@ pub const Logind = struct {
     pub fn close(self: *Logind, fd: i32) !void {
         var x = try releaseDevice(self.bus, self.session_path, fd);
         var y = linux.close(fd);
-        if (self.devices.remove(fd)) |path| {
+        if (self.devices.fetchRemove(fd)) |path| {
             std.heap.c_allocator.free(path.value);
         }
     }

--- a/src/output.zig
+++ b/src/output.zig
@@ -17,7 +17,7 @@ pub const Output = struct {
         while (client_it.next()) |client| {
             var obj_it = client.context.objects.iterator();
             while (obj_it.next()) |wl_object_entry| {
-                var wl_object = wl_object_entry.value;
+                var wl_object = wl_object_entry.value_ptr;
                 if (@ptrToInt(self) == wl_object.container) {
                     // TODO: in release mode do not error
                     const wl_registry_id = client.wl_registry_id orelse return error.ClientHasNoRegistry;

--- a/src/wl/context.zig
+++ b/src/wl/context.zig
@@ -157,7 +157,7 @@ pub fn Context(comptime T: type) type {
         }
 
         pub fn unregister(self: *Self, object: Object) !void {
-            if (self.objects.remove(object.id)) |x| {
+            if (self.objects.remove(object.id)) {
                 // std.debug.warn("unregistered: {}\n", .{x.key});
             } else {
                 std.debug.warn("attempted to deregister object ({}) that didn't exist\n", .{object.id});


### PR DESCRIPTION
# Description

- I thought I'd made fixes for zig 0.8 but I had failed to update the GitHub Action zig version explicitly, so I'm not sure what version was pulled in that allowed https://github.com/malcolmstill/foxwhale/pull/51 to pass)
- There were thorough changes to hashmaps (see https://ziglang.org/download/0.8.0/release-notes.html)
    - `remove` has become `fetchRemove`
    - `.value` has become `.value_ptr`
- `sendmsg` / `recvmsg` now take `std.x.os.Socket.Message` and there is a `sendmsg` now in `std.os`
    - call `os.sendmsg` instead of `linux.sendmsg + retry logic`
    - cast to `std.x.os.Socket.Message` for `recvmsg`